### PR TITLE
Update package naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This package is available for several languages/platforms:
 To use from JavaScript or TypeScript in Node.js, install using either `npm`:
 
 ```bash
-npm install @symbiosis-cloud/symbiosis
+npm install @symbiosis-cloud/symbiosis-pulumi
 ```
 
 or `yarn`:
 
 ```bash
-yarn add @symbiosis-cloud/symbiosis
+yarn add @symbiosis-cloud/symbiosis-pulumi
 ```
 
 ### Python
@@ -25,7 +25,7 @@ yarn add @symbiosis-cloud/symbiosis
 To use from Python, install using `pip`:
 
 ```bash
-pip install symbiosis_pulumi
+pip install symbiosis-pulumi
 ```
 
 ### Go
@@ -41,7 +41,7 @@ go get github.com/symbiosis-cloud/pulumi-symbiosis/sdk/go/...
 To use from .NET, install using `dotnet add package`:
 
 ```bash
-dotnet add package Symbiosis.SymbiosisPulumi
+dotnet add package Symbiosis.Pulumi.Symbiosis
 ```
 
 ## Configuration

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -37,7 +37,7 @@ db = symbiosis.Cluster("example",
 
 ```go
 import (
-	"github.com/symbiosis/pulumi-symbiosis/sdk/go/symbiosis"
+	"github.com/symbiosis-cloud/pulumi-symbiosis/sdk/go/symbiosis"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -59,7 +59,7 @@ func main() {
 
 ```csharp
 using Pulumi;
-using Symbiosis.Symbiosis;
+using Symbiosis.Pulumi.Symbiosis;
 
 class ExampleCluster : Stack
 {

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -8,10 +8,10 @@ layout: installation
 
 The Kuraudo.io Symbiosis provider is available as a package in all Pulumi languages:
 
-* JavaScript/TypeScript: [`@kuraudo-io/symbiosis`](https://www.npmjs.com/package/@kuraudo-io/symbiosis)
-* Python: [`kuraudo_symbiosis`](https://pypi.org/project/kuraudo-symbiosis/)
-* Go: [`github.com/kuraudo-io/pulumi-symbiosis/sdk/go/unifi`](https://pkg.go.dev/github.com/kuraudo-io/pulumi-symbiosis/sdk/go/symbiosis)
-* .NET: [`Kuraudo.Symbiosis`](https://www.nuget.org/packages/Kuraudo.Symbiosis)
+* JavaScript/TypeScript: [`@symbiosis-cloud/symbiosis-pulumi`](https://www.npmjs.com/package/@symbiosis-cloud/symbiosis-pulumi)
+* Python: [`symbiosis-pulumi`](https://pypi.org/project/symbiosis-pulumi/)
+* Go: [`github.com/symbiosis-cloud/pulumi-symbiosis/sdk/go/symbiosis`](https://pkg.go.dev/github.com/symbiosis-cloud/pulumi-symbiosis/sdk/go/symbiosis)
+* .NET: [`Symbiosis.Pulumi.Symbiosis`](https://www.nuget.org/packages/Symbiosis.Pulumi.Symbiosis)
 
 ## Setup
 


### PR DESCRIPTION
Noticed some package names still pointed at kuraudo-io, or were incorrect based on what's in the various package registries. This should fix the documentation to reflect the correct naming. :)